### PR TITLE
parse_event condition added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Visual Studio Code stuff
+.vscode

--- a/bot.py
+++ b/bot.py
@@ -19,11 +19,12 @@ class Bot(object):
 		if api_call.get('ok'):
 			# retrieve all users so we can find our bot
 			users = api_call.get('members')
+			user_id = None
 			for user in users:
 				if 'name' in user and user.get('name') == self.bot_name:
-					return "<@" + user.get('id') + ">"
+					user_id =  "<@" + user.get('id') + ">"
 			
-			return None
+		return user_id
 			
 	def listen(self):
 		if self.slack_client.rtm_connect(with_team_state=False):

--- a/event.py
+++ b/event.py
@@ -14,7 +14,7 @@ class Event:
 				self.parse_event(event)
 				
 	def parse_event(self, event):
-		if event and 'text' in event and self.bot.bot_id in event['text']:
+		if event and event['type'] == 'message' and self.bot.bot_id in event['text'] and event['user'] not in self.bot.bot_id:
 			self.handle_event(event['user'], event['text'].split(self.bot.bot_id)[1].strip().lower(), event['channel'])
 	
 	def handle_event(self, user, command, channel):


### PR DESCRIPTION
If the bot was invited to a channel, it would mention itself in the invite announcement, thus creating an infinite loop of default "didn't understand" messages. 

In event.py:
I added an AND condition to prevent that.

In bot.py:
I changed how the get_bot_id returned the output, but that's more of a frivolous edit.

PS-found your code from your blog. Great work, thanks, it helped me get my bot started!